### PR TITLE
fix Python 3.12 builds

### DIFF
--- a/aksetup_helper.py
+++ b/aksetup_helper.py
@@ -35,10 +35,14 @@ def setup(*args, **kwargs):
 
 
 def get_numpy_incpath():
-    from imp import find_module
+    from os.path import join, basename
     # avoid actually importing numpy, it screws up distutils
-    file, pathname, descr = find_module("numpy")
-    from os.path import join
+    try:
+        from imp import find_module
+        file, pathname, descr = find_module("numpy")
+    except ImportError:
+        from importlib import util
+        pathname = basename(util.find_spec("numpy").origin)
     return join(pathname, "core", "include")
 
 


### PR DESCRIPTION
`imp` has been removed in Python 3.12.
This updates the `get_numpy_incpath` function to use `importlib` if `imp` is not found.

This preserves compatibility with ancient versions of Python3.
A better solution would be to remove `imp` completely - let me know if you would prefer that.